### PR TITLE
`which-key-posframe--hide' performance optimization

### DIFF
--- a/which-key-posframe.el
+++ b/which-key-posframe.el
@@ -124,24 +124,23 @@ characters respectably."
   :global t
   :lighter nil
   (if which-key-posframe-mode
-      (progn
-	(setq which-key-popup-type--previous which-key-popup-type
-	      which-key-custom-show-popup-function--previous which-key-custom-show-popup-function
-	      which-key-custom-hide-popup-function--previous which-key-custom-hide-popup-function
-	      which-key-custom-popup-max-dimensions-function--previous which-key-custom-popup-max-dimensions-function
-	      which-key-popup-type 'custom
-	      which-key-custom-show-popup-function 'which-key-posframe--show-buffer
-	      which-key-custom-hide-popup-function 'which-key-posframe--hide
-	      which-key-custom-popup-max-dimensions-function 'which-key-posframe--max-dimensions))
+      (setq which-key-popup-type--previous which-key-popup-type
+            which-key-custom-show-popup-function--previous which-key-custom-show-popup-function
+            which-key-custom-hide-popup-function--previous which-key-custom-hide-popup-function
+            which-key-custom-popup-max-dimensions-function--previous which-key-custom-popup-max-dimensions-function
+            which-key-popup-type 'custom
+            which-key-custom-show-popup-function 'which-key-posframe--show-buffer
+            which-key-custom-hide-popup-function 'which-key-posframe--hide
+            which-key-custom-popup-max-dimensions-function 'which-key-posframe--max-dimensions)
     (posframe-delete which-key--buffer)
     (setq which-key-popup-type which-key-popup-type--previous
-	  which-key-custom-show-popup-function which-key-custom-show-popup-function--previous
-	  which-key-custom-hide-popup-function which-key-custom-hide-popup-function--previous
-	  which-key-custom-popup-max-dimensions-function which-key-custom-popup-max-dimensions-function--previous
-	  which-key-popup-type--previous nil
-	  which-key-custom-show-popup-function--previous nil
-	  which-key-custom-hide-popup-function--previous nil
-	  which-key-custom-popup-max-dimensions-function--previous nil)))
+          which-key-custom-show-popup-function which-key-custom-show-popup-function--previous
+          which-key-custom-hide-popup-function which-key-custom-hide-popup-function--previous
+          which-key-custom-popup-max-dimensions-function which-key-custom-popup-max-dimensions-function--previous
+          which-key-popup-type--previous nil
+          which-key-custom-show-popup-function--previous nil
+          which-key-custom-hide-popup-function--previous nil
+          which-key-custom-popup-max-dimensions-function--previous nil)))
 
 (provide 'which-key-posframe)
 

--- a/which-key-posframe.el
+++ b/which-key-posframe.el
@@ -81,11 +81,16 @@ When 0, no border is showed."
 (defvar which-key-custom-popup-max-dimensions-function--previous nil
   "The previous value of `which-key-custom-popup-max-dimensions-function'")
 
+(defvar which-key-posframe--popup-visible nil
+  ;; workaround for https://github.com/yanghaoxie/which-key-posframe/issues/7
+  "Whether or not the which-key-posframe popup is currently visible.")
+
 (defun which-key-posframe--show-buffer (act-popup-dim)
   "Show which-key buffer when popup type is posframe.
 Argument ACT-POPUP-DIM includes the dimension, (height . width)
 of the buffer text to be displayed in the popup"
   (when (posframe-workable-p)
+    (setq which-key-posframe--popup-visible t)
     (save-window-excursion
       (posframe-show
        which-key--buffer
@@ -102,7 +107,9 @@ of the buffer text to be displayed in the popup"
 
 (defun which-key-posframe--hide ()
   "Hide which-key buffer when posframe popup is used."
-  (when (buffer-live-p which-key--buffer)
+  (when (and (buffer-live-p which-key--buffer)
+             which-key-posframe--popup-visible)
+    (setq which-key-posframe--popup-visible nil)
     (posframe-hide which-key--buffer)))
 
 (defun which-key-posframe--max-dimensions (_)


### PR DESCRIPTION
Track popup visibility and only call `posframe--hide` when popup is known to be visible.

Fixes https://github.com/yanghaoxie/which-key-posframe/issues/7