### PR TITLE
修复 win10 不能通过 straight.el 安装

### DIFF
--- a/which-key-posframe.el
+++ b/which-key-posframe.el
@@ -139,7 +139,7 @@ characters respectably."
 (provide 'which-key-posframe)
 
 ;; Local Variables:
-;; coding: utf-8-unix
+;; coding: utf-8
 ;; End:
 
 ;;; which-key-posframe.el ends here


### PR DESCRIPTION
Install package via straight.el on win10.

CONFIG:
```elisp
(use-package which-key-posframe
  :after (which-key posframe)
  :config
  (which-key-posframe-mode))
```
ERROR: 
`which-key-posframe.el:0:0: error: error: (Local variables entry is missing the suffix)`