### PR TITLE
Preserve truncation of lines

### DIFF
--- a/which-key-posframe.el
+++ b/which-key-posframe.el
@@ -96,6 +96,7 @@ of the buffer text to be displayed in the popup"
        :foreground-color (face-attribute 'which-key-posframe :foreground nil t)
        :height (car act-popup-dim)
        :width (cdr act-popup-dim)
+       :lines-truncate t
        :internal-border-width which-key-posframe-border-width
        :internal-border-color (face-attribute 'which-key-posframe-border :background nil t)
        :override-parameters which-key-posframe-parameters))))

--- a/which-key-posframe.el
+++ b/which-key-posframe.el
@@ -110,7 +110,8 @@ of the buffer text to be displayed in the popup"
   "Return max-dimensions of posframe.
 The returned value has the form (HEIGHT . WIDTH) in lines and
 characters respectably."
-  (cons (1- (frame-height)) (frame-width)))
+  (cons (- (frame-height) 2) ; account for mode-line and minibuffer
+	(frame-width)))
 
 ;;;###autoload
 (define-minor-mode which-key-posframe-mode nil


### PR DESCRIPTION
Lines are set to be truncated in `which-key--init-buffer` but
because `posframe-show` always sets `truncate-lines` based on
its `:lines-truncate` argument, even when that is unspecified
(in which case it defaults to `nil`), we have to double down
on this.